### PR TITLE
Cache babel results

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -31,6 +31,8 @@ module.exports = ({ mode }) => {
             loader: 'babel-loader',
             options: {
               presets: ['@babel/preset-env'],
+              // cache transpilation results to speed up build
+              cacheDirectory: true,
             },
           },
         },


### PR DESCRIPTION
This commit adds a config option to the babel loader telling it to
preserve the output of the transpilation process in cache.
This speeds up the build process a little.

More details: https://github.com/babel/babel-loader#options